### PR TITLE
feat: add conjugation fix to re-chunker

### DIFF
--- a/core/rechunk-fast.py
+++ b/core/rechunk-fast.py
@@ -93,7 +93,9 @@ def find_all_files(
 
 
 def get_file_time_slices(
-    meta_list: list[FastUVH5Meta], lsts_per_chunk: int, lst_wrap: float
+    meta_list: list[FastUVH5Meta],
+    lsts_per_chunk: int,
+    lst_wrap: float,
 ):
     """Get the time slices in each file that need to be taken."""
     dlst = -1
@@ -291,7 +293,7 @@ def chunk_files(
     # Get the slices we'll need for each chunk.
     logger.info("Getting time slices for each output file...")
     chunk_slices = get_file_time_slices(
-        raw_files[channels[0]], n_times_per_file, lst_wrap
+        raw_files[channels[0]], n_times_per_file, lst_wrap, time_first
     )
     logger.info("Got all time slices")
 
@@ -466,6 +468,11 @@ def write_freq_chunk(
             if data.ndim > 3:
                 raise ValueError(
                     "Data has old array shapes. Please make it future array shapes."
+                )
+
+            if data.shape[0] < this_nblts:
+                raise ValueError(
+                    f"Data in {pth} has fewer blts than expected ({data.shape[0]} < {this_nblts})."
                 )
 
         full_dset[nblts_so_far : nblts_so_far + this_nblts, ich - start_index] = data[

--- a/core/rechunk-fast.py
+++ b/core/rechunk-fast.py
@@ -18,8 +18,8 @@ from pathlib import Path
 import h5py
 import numpy as np
 import psutil
-from hera_cli_tools import parse_args, run_with_profiling
-from pyuvdata.uvdata.uvh5 import FastUVH5Meta
+from hera_cli_utils import parse_args, run_with_profiling
+from pyuvdata.uvdata import FastUVH5Meta
 
 logger = logging.getLogger("rechunk")
 ps = psutil.Process()

--- a/core/rechunk-fast.py
+++ b/core/rechunk-fast.py
@@ -479,7 +479,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--channels",
         type=str,
-        help='the channels to read, in the form "low~high", eg "0~1535"',
+        help='the channels to read, in the form "low~high", eg "0~1536"',
         nargs="+",
     )
     parser.add_argument(

--- a/core/rechunk-fast.py
+++ b/core/rechunk-fast.py
@@ -451,7 +451,17 @@ def write_freq_chunk(
             else:
                 slices = slice(nbls * slc.start, nbls * (slc.start + this_ntimes))
 
-            data = fl["/Data/visdata"][slices]
+            data = fl["/Data/visdata"]
+
+            logger.debug(
+                f"Reading file {pth} with slices {slices} for channel {ch}."
+                f"Data has shape {data.shape}. This chunk has {this_ntimes} times and "
+                f"{this_nblts} blts."
+            )
+
+            data = data[slices]
+
+            logger.debug(f"After slicing out times, data has shape {data.shape}.")
 
             if data.ndim > 3:
                 raise ValueError(

--- a/core/utils.py
+++ b/core/utils.py
@@ -1,18 +1,13 @@
 """Some common utilities used throughout the core modules."""
 
+import logging
 from os import environ
 from pathlib import Path
 
 import numpy as np
 import yaml
 
-HPC = environ.get("VALIDATION_SYSTEM_NAME")
-
-if HPC is None:
-    raise OSError(
-        "You must set the VALIDATION_SYSTEM_NAME environment variable to your system "
-        "name, corresponding to a file in hpc-configs."
-    )
+logger = logging.getLogger(__name__)
 
 # These paths and variables define some of the default directories and shared
 # config files for H4C validation simulations
@@ -38,8 +33,17 @@ VIS_FLFMT = FLFMT
 
 COMPRESS_FMT = "ch{chunks}_{layout_file}.npy"
 
-with open(HPCDIR / f"{HPC}.yaml") as fl:
-    HPC_CONFIG = yaml.load(fl, Loader=yaml.FullLoader)
+HPC = environ.get("VALIDATION_SYSTEM_NAME")
+
+if HPC is None:
+    logger.warn(
+        "You must set the VALIDATION_SYSTEM_NAME environment variable to your system "
+        "name, corresponding to a file in hpc-configs. Assuming local system.",
+    )
+    HPC_CONFIG = None
+else:
+    with open(HPCDIR / f"{HPC}.yaml") as fl:
+        HPC_CONFIG = yaml.load(fl, Loader=yaml.FullLoader)
 
 LAYOUTDIR = CFGDIR / "array_layouts"
 

--- a/hpc-configs/NRAO.yaml
+++ b/hpc-configs/NRAO.yaml
@@ -1,33 +1,26 @@
 # Template for HPC config for run_sim.py
 # None-number values should be quoted 
 
-paths:
-  beams: "/ocean/projects/phy210034p/sgm/hera-beams/NicolasFagnoniBeams"
+paths:   
+  beams: "/lustre/aoc/projects/hera/Validation/HERA_beams/"
 
 conda:
   # Path will be resolved
   conda_path: "~/miniconda3"
-  environment_name: "h6c"
+  environment_name: "h4c-sim"
 
 module:
   # List environment modules to load
-  - "openmpi"
-  - "cuda/11.7.1"
+  - "mpi"
 
 slurm:
   # SLURM SBATCH options, listed as --flag: value
   # Flags not shown here should work
+  # There is no GPU on NRAO!
   cpu:
-    partition: "RM"  # Name of partition
+    partition: "batch"  # Name of partition
     nodes: 1  # Number of nodes
     mem: "24GB"  # Memory with unit
     ntasks: 1  # Number of tasks
     time: "0-00:60:00"  # slurm-aware time string format
-  gpu:
-    partition: "GPU-shared"  # Name of partition
-    nodes: 1                 # Number of nodes
-    mem: "23GB"              # Memory with unit
-    ntasks: 1                # Number of tasks
-    time: "0-00:60:00"       # slurm-aware time string format
-    gres: "gpu:v100-32:1"    # the v100-32 identifier ensures we use the V100 nodes with 32GB
     

--- a/notebooks/make_eor_alternatives.ipynb
+++ b/notebooks/make_eor_alternatives.ipynb
@@ -1,0 +1,370 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "169b927c",
+   "metadata": {
+    "toc": true
+   },
+   "source": [
+    "<h1>Table of Contents<span class=\"tocSkip\"></span></h1>\n",
+    "<div class=\"toc\"><ul class=\"toc-item\"></ul></div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c7c39aab",
+   "metadata": {},
+   "source": [
+    "Make a couple of different EOR sky models for testing: one that is upscaled to Nside=256, and one where the pixels are rotated arbitrarily"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 60,
+   "id": "3fb8443c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pyradiosky import SkyModel\n",
+    "import healpy as hp\n",
+    "from pathlib import Path\n",
+    "import numpy as np\n",
+    "import h5py\n",
+    "from astropy import units as un\n",
+    "from astropy.coordinates import spherical_to_cartesian, cartesian_to_spherical, SkyCoord"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "9283b457",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sm = Path(\"../sky_models\")\n",
+    "eor = sm / 'eor'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "29953b83",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'icrs'"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "first_sky.frame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "id": "6ce1c8dd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "out_params = {\n",
+    "    \"component_type\": \"healpix\",\n",
+    "    \"nside\": 256,\n",
+    "    \"hpx_inds\": np.arange(hp.nside2npix(256)),\n",
+    "    \"hpx_order\": \"ring\",\n",
+    "    \"spectral_type\": \"full\",\n",
+    "    #\"freq_array\": freq,\n",
+    "    #\"stokes\": stokes,\n",
+    "    \"frame\": 'icrs',\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "aad10199",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "first_sky.write_skyh5?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "15632006",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(sm / 'eor256').mkdir()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "id": "5755d27f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "stokes256 = np.zeros((4, 1, hp.nside2npix(256))) * first_sky.stokes.unit\n",
+    "\n",
+    "for ch in range(175, 325):\n",
+    "    with h5py.File(eor / f\"fch0{ch}.skyh5\", 'r') as fl:\n",
+    "        mp = fl['Data']['stokes'][0,0]\n",
+    "        freq = fl['Header']['freq_array'][()] * un.Hz\n",
+    "        stokes256[0] = hp.ud_grade(mp, nside_out=256) * first_sky.stokes.unit\n",
+    "        \n",
+    "        sky_model = SkyModel(freq_array=freq, stokes=stokes256, **out_params)    \n",
+    "        sky_model.write_skyh5(sm / 'eor256' / f\"fch0{ch}.skyh5\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "id": "e3a4f2b7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from scipy.spatial.transform import Rotation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "id": "85ea6740",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r = Rotation.from_euler('xyz', [np.pi/6, np.pi/10.7, np.pi/17.8])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "id": "238925a7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "spherical_to_cartesian?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "id": "049885fa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "skypoint = first_sky.copy()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "id": "fc04f88d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "skypoint.healpix_to_point()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 54,
+   "id": "115d0ae8",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<SkyCoord (ICRS): (ra, dec) in deg\n",
+       "    [( 45.,  89.6345165), (135.,  89.6345165), (225.,  89.6345165), ...,\n",
+       "     (135., -89.6345165), (225., -89.6345165), (315., -89.6345165)]>"
+      ]
+     },
+     "execution_count": 54,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "skypoint.skycoord"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 62,
+   "id": "6d2c86ce",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(sm / 'eor-rotated').mkdir()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 63,
+   "id": "ac50cf40",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "stokes = np.zeros((4, 1, hp.nside2npix(128))) * first_sky.stokes.unit\n",
+    "\n",
+    "for ch in range(175, 325):\n",
+    "    sky = SkyModel.from_skyh5(eor / f\"fch0{ch}.skyh5\")\n",
+    "    sky.healpix_to_point()\n",
+    "    \n",
+    "    lon, lat = sky.get_lon_lat()\n",
+    "    x,y,z = spherical_to_cartesian(r=1, lat=lat, lon=lon)\n",
+    "    x,y,z = r.apply(np.array([x,y,z]).T).T\n",
+    "    _, lat, lon = cartesian_to_spherical(x,y,z)\n",
+    "    \n",
+    "    sky.skycoord = SkyCoord(lon, lat, frame='icrs')\n",
+    "    sky.write_skyh5(sm / 'eor-rotated' / f\"fch0{ch}.skyh5\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "b3d8b741",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lon, lat = first_sky.get_lon_lat()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "3db27fe5",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([0.78539816, 2.35619449, 3.92699082, ..., 2.35619449, 3.92699082,\n",
+       "       5.49778714])"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "lon.rad"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "86e4aae7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lon = lon.rad\n",
+    "lat = lat.rad"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "e9620969",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "stokes = first_sky.stokes[0,0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "c7a378a0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hp.ud_grade?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "ec16cb76",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "stokes256 = hp.ud_grade(stokes, nside_out=256)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "e1d173b9",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(786432,)"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "stokes256.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9140fd51",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "h4c-sim",
+   "language": "python",
+   "name": "h4c-sim"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.13"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": true,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": true,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/vis_sim_test.ipynb
+++ b/notebooks/vis_sim_test.ipynb
@@ -1,6 +1,17 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "id": "eb87534e",
+   "metadata": {
+    "toc": true
+   },
+   "source": [
+    "<h1>Table of Contents<span class=\"tocSkip\"></span></h1>\n",
+    "<div class=\"toc\"><ul class=\"toc-item\"><li><span><a href=\"#Using-all-available-baseline-lengths\" data-toc-modified-id=\"Using-all-available-baseline-lengths-1\"><span class=\"toc-item-num\">1&nbsp;&nbsp;</span>Using all available baseline lengths</a></span></li><li><span><a href=\"#Using-only-short-baselines\" data-toc-modified-id=\"Using-only-short-baselines-2\"><span class=\"toc-item-num\">2&nbsp;&nbsp;</span>Using only short baselines</a></span></li></ul></div>"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "34129cc3",
@@ -1204,6 +1215,19 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.10.6"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": true,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": true,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
   }
  },
  "nbformat": 4,

--- a/submit-rechunk.sh
+++ b/submit-rechunk.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+#SBATCH --time=06:00:00
+#SBATCH --mem=23GB
+#SBATCH --nodes=1
+#SBATCH --cpus-per-task=16
+
+source ~/miniconda3/bin/activate
+conda activate h4c-sim
+
+time python core/rechunk-fast.py \
+  --r-prototype "eor_fch{channel:04d}_nt17280_chunk0.uvh5" \
+  --chunk-size 2 \
+  --channels 0~1536 \
+  --sky-cmp eor \
+  --assume-same-blt-layout \
+  --is-rectangular \
+  --nthreads 16 \
+  --conjugate \
+  --remove-cross-pols \
+  /home/herastore02-1/Validation/H4C-Simulations/eor/nt17280 \
+  outputs/eor/rechunk

--- a/vsim.py
+++ b/vsim.py
@@ -184,7 +184,7 @@ def cornerturn(
 
     if channels is None:
         allfiles = sorted(
-            simdir.glob(f"{sky_model}_fch????_nt17280_chunk${time_chunk}.uvh5")
+            simdir.glob(f"{sky_model}_fch????_nt17280_chunk{time_chunk}.uvh5")
         )
         maxchan = int(allfiles[-1].split("fch")[1][:4])
         if len(allfiles) != maxchan + 1:

--- a/vsim.py
+++ b/vsim.py
@@ -186,7 +186,7 @@ def cornerturn(
     nchannels = int(channels.split("~")[1]) - int(channels.split("~")[0])
     estimated_time = 36 * nchannels / 1536  # hours
 
-    estimated_minutes = max(int(estimated_time - int(estimated_time)) * 60, 1)
+    estimated_minutes = max(int(estimated_time - int(estimated_time)) * 60, 10)
 
     if estimated_time > 24:
         estimated_time = f"1-{int(estimated_time)-24:02d}:{estimated_minutes:02d}:00"
@@ -206,7 +206,7 @@ def cornerturn(
     sbatch = _cli._get_sbatch_program(gpu=False, slurm_override=slurm_override)
 
     cmd = f"""
-    time python rechunk-fast.py \
+    time python core/rechunk-fast.py \
     --r-prototype "{sky_model}_fch{{channel:04d}}_nt17280_chunk{time_chunk}.uvh5" \
     --chunk-size {new_chunk_size} \
     --channels {channels} \

--- a/vsim.py
+++ b/vsim.py
@@ -129,6 +129,7 @@ def sky_model(
     type=str,
     help="Channels to use, e.g. '0~1536'. If not given, all channels are used.",
 )
+@_cli.opts.log_level
 @_cli.opts.dry_run
 @_cli.opts.slurm_override
 def cornerturn(
@@ -142,6 +143,7 @@ def cornerturn(
     remove_cross_pols: bool,
     direc: Path | None,
     channels: str | None,
+    log_level: str,
 ):
     """Perform a cornerturn on simulation files.
 
@@ -152,6 +154,8 @@ def cornerturn(
     Output files have the following prototype:
         zen.LST.{lst:.7f}[.{sky_cmp}].uvh5
     """
+    logger.setLevel(log_level)
+
     # Make sure that the slurm log directory exists.
     # Otherwise, the job will terminate
     log_dir = Path(f"logs/chunk/{sky_model}")
@@ -202,6 +206,7 @@ def cornerturn(
     --nthreads 16 \
     {conjugate} \
     {remove_cross_pols} \
+    --log-level {log_level} \
     {simdir} \
     {outdir} \
     """
@@ -218,3 +223,7 @@ def cornerturn(
         subprocess.call(f"sbatch {sbatch_file}".split())
 
     logger.debug(f"\n===Job Script===\n{sbatch}\n===END===\n")
+
+
+if __name__ == "__main__":
+    cli()

--- a/vsim.py
+++ b/vsim.py
@@ -186,10 +186,12 @@ def cornerturn(
     nchannels = int(channels.split("~")[1]) - int(channels.split("~")[0])
     estimated_time = 36 * nchannels / 1536  # hours
 
+    estimated_minutes = max(int(estimated_time - int(estimated_time)) * 60, 1)
+
     if estimated_time > 24:
-        estimated_time = f"1-{int(estimated_time)-24:02d}:00:00"
+        estimated_time = f"1-{int(estimated_time)-24:02d}:{estimated_minutes:02d}:00"
     else:
-        estimated_time = f"{int(estimated_time):02d}:00:00"
+        estimated_time = f"{int(estimated_time):02d}:{estimated_minutes:02d}:00"
 
     slurm_override = slurm_override + (
         ("job-name", f"{sky_model}-ct"),

--- a/vsim.py
+++ b/vsim.py
@@ -168,7 +168,11 @@ def cornerturn(
     else:
         simdir = Path(direc)
 
-    outdir = simdir / "rechunk"
+    outdir = (
+        utils.OUTDIR
+        / utils.VIS_DIRFMT.format(sky_model=sky_model, chunks=nchunks_sim)
+        / "rechunk"
+    )
     outdir.mkdir(parents=True, exist_ok=True)
 
     conjugate = "--conjugate" if conjugate else ""

--- a/vsim.py
+++ b/vsim.py
@@ -193,7 +193,7 @@ def cornerturn(
 
     cmd = f"""
     time python rechunk-fast.py \
-    --r-prototype "{sky_model}_fch{{channel:04d}}_nt17280_chunk${time_chunk}.uvh5" \
+    --r-prototype "{sky_model}_fch{{channel:04d}}_nt17280_chunk{time_chunk}.uvh5" \
     --chunk-size {new_chunk_size} \
     --channels {channels} \
     --sky-cmp {sky_model}\
@@ -205,7 +205,6 @@ def cornerturn(
     {simdir} \
     {outdir} \
     """
-
     sbatch_dir = utils.REPODIR / "batch_scripts/rechunk"
     sbatch_dir.mkdir(parents=True, exist_ok=True)
 

--- a/vsim.py
+++ b/vsim.py
@@ -129,6 +129,7 @@ def sky_model(
     type=str,
     help="Channels to use, e.g. '0~1536'. If not given, all channels are used.",
 )
+@_cli.opts.layout
 @_cli.opts.log_level
 @_cli.opts.dry_run
 @_cli.opts.slurm_override
@@ -144,6 +145,7 @@ def cornerturn(
     direc: Path | None,
     channels: str | None,
     log_level: str,
+    layout: str,
 ):
     """Perform a cornerturn on simulation files.
 
@@ -163,14 +165,16 @@ def cornerturn(
 
     if direc is None:
         simdir = utils.OUTDIR / utils.VIS_DIRFMT.format(
-            sky_model=sky_model, chunks=nchunks_sim
+            sky_model=sky_model, chunks=nchunks_sim, layout=layout
         )
     else:
         simdir = Path(direc)
 
     outdir = (
         utils.OUTDIR
-        / utils.VIS_DIRFMT.format(sky_model=sky_model, chunks=nchunks_sim)
+        / utils.VIS_DIRFMT.format(
+            sky_model=sky_model, chunks=nchunks_sim, layout=layout
+        )
         / "rechunk"
     )
     outdir.mkdir(parents=True, exist_ok=True)

--- a/vsim.py
+++ b/vsim.py
@@ -187,9 +187,9 @@ def cornerturn(
     estimated_time = 36 * nchannels / 1536  # hours
 
     if estimated_time > 24:
-        estimated_time = f"1-{estimated_time-24:02d}:00:00"
+        estimated_time = f"1-{int(estimated_time)-24:02d}:00:00"
     else:
-        estimated_time = f"{estimated_time:02d}:00:00"
+        estimated_time = f"{int(estimated_time):02d}:00:00"
 
     slurm_override = slurm_override + (
         ("job-name", f"{sky_model}-ct"),

--- a/vsim.py
+++ b/vsim.py
@@ -186,7 +186,7 @@ def cornerturn(
         allfiles = sorted(
             simdir.glob(f"{sky_model}_fch????_nt17280_chunk{time_chunk}.uvh5")
         )
-        maxchan = int(allfiles[-1].split("fch")[1][:4])
+        maxchan = int(allfiles[-1].name.split("fch")[1][:4])
         if len(allfiles) != maxchan + 1:
             raise ValueError(f"Missing files in {simdir}")
         channels = f"0~{maxchan+1}"


### PR DESCRIPTION
Adds two options to rechunker: `--conjugate` to fix a bug in old `vis_cpu` versions, and `--remove-cross-pols` to ignore cross-pols when making the re-chunked files.