### PR TITLE
Fix cornerturn

### DIFF
--- a/core/rechunk-fast.py
+++ b/core/rechunk-fast.py
@@ -273,8 +273,10 @@ def chunk_files(
 
     if remove_cross_pols:
         pol_indices = [i for i, pol in enumerate(meta.pols) if pol[0] == pol[1]]
-        uvd.Npols = len(pol_indices)
-        uvd.polarization_array = meta.polarization_array[pol_indices]
+    else:
+        pol_indices = [i for i, pol in enumerate(meta.pols)]
+    uvd.Npols = len(pol_indices)
+    uvd.polarization_array = meta.polarization_array[pol_indices]
 
     DTYPE = np.dtype(complex) if uvd.data_array is None else uvd.data_array.dtype
 
@@ -293,7 +295,7 @@ def chunk_files(
     # Get the slices we'll need for each chunk.
     logger.info("Getting time slices for each output file...")
     chunk_slices = get_file_time_slices(
-        raw_files[channels[0]], n_times_per_file, lst_wrap, time_first
+        raw_files[channels[0]], n_times_per_file, lst_wrap
     )
     logger.info("Got all time slices")
 

--- a/hpc-configs/ilifu.yaml
+++ b/hpc-configs/ilifu.yaml
@@ -12,7 +12,7 @@ conda:
 module:
   # List environment modules to load
   - "openmpi"
-  - "cuda"
+  - "cuda/11.8"
 
 slurm:
   # SLURM SBATCH options, listed as --flag: value
@@ -23,12 +23,13 @@ slurm:
     nodes: 1  # Number of nodes
     mem: "24GB"  # Memory with unit
     ntasks: 1  # Number of tasks
-    time: "0-00:60:00"  # slurm-aware time string format
+    cpus-per-task: 2
+    time: "1-12:00:00"  # slurm-aware time string format
   gpu:
     partition: "GPU"  # Name of partition
     nodes: 1  # Number of nodes
-    mem: "24GB"  # Memory with unit
+    mem: "20GB"  # Memory with unit
     ntasks: 1  # Number of tasks
-    time: "0-00:60:00"  # slurm-aware time string format
+    time: "0-03:00:00"  # slurm-aware time string format
     gres: "gpu:1"  # Some cluster do not support --gpus flag
     

--- a/vsim.py
+++ b/vsim.py
@@ -184,7 +184,7 @@ def cornerturn(
 
     if channels is None:
         allfiles = sorted(
-            simdir.glob(f"{sky_model}_fch????_nt17280_chunk{time_chunk}.uvh5")
+            simdir.glob(f"{sky_model}_fch????_nt17280_chunk{time_chunk:03d}_{layout}.uvh5")
         )
         maxchan = int(allfiles[-1].name.split("fch")[1][:4])
         if len(allfiles) != maxchan + 1:
@@ -215,7 +215,7 @@ def cornerturn(
 
     cmd = f"""
     time python core/rechunk-fast.py \
-    --r-prototype "{sky_model}_fch{{channel:04d}}_nt17280_chunk{time_chunk}.uvh5" \
+    --r-prototype "{sky_model}_fch{{channel:04d}}_nt17280_chunk{time_chunk:03d}_{layout}.uvh5" \
     --chunk-size {new_chunk_size} \
     --channels {channels} \
     --sky-cmp {sky_model}\
@@ -231,7 +231,7 @@ def cornerturn(
     sbatch_dir = utils.REPODIR / "batch_scripts/rechunk"
     sbatch_dir.mkdir(parents=True, exist_ok=True)
 
-    sbatch_file = sbatch_dir / f"{sky_model}_ch{time_chunk}.sbatch"
+    sbatch_file = sbatch_dir / f"{sky_model}_ch{time_chunk:03d}_{layout}.sbatch"
 
     sbatch = "\n".join([sbatch, "", cmd, ""])
     with open(sbatch_file, "w") as fl:


### PR DESCRIPTION
This PR fix small bugs in `vsim.py cornerturn`, i.e. #16 #17 and #18 . It also updates default slurm parameters for running H4C simulations on Ilifu.