### PR TITLE
docs: note that you need CUDA 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ debugging, etc.)
       `gpus`). In general, you should use as much `mem` as available on a single node
       on your system, and use `nodes=1` (as multiple nodes are used via multiple
       jobs).
+4. Note that CUDA 11 is required (NOT Cuda 12), so ensure that the loaded modules are
+   correct. You can check this by running `module list` on your system.
 
 ### Running a Simulation
 

--- a/vsim.py
+++ b/vsim.py
@@ -31,9 +31,8 @@ def cli():
     pass
 
 
-@cli.command("runsim")
 @_cli.opts.add_opts
-def hera_cli(channels, freq_range, **kwargs):
+def runsim(channels, freq_range, **kwargs):
     """Run HERA validation simulations.
 
     Use the default parameters, configuration files, and directories for HERA sims
@@ -193,7 +192,9 @@ def cornerturn(
 
     if channels is None:
         allfiles = sorted(
-            simdir.glob(f"{sky_model}_fch????_nt17280_chunk{time_chunk:03d}_{layout}.uvh5")
+            simdir.glob(
+                f"{sky_model}_fch????_nt17280_chunk{time_chunk:03d}_{layout}.uvh5"
+            )
         )
         maxchan = int(allfiles[-1].name.split("fch")[1][:4])
         if len(allfiles) != maxchan + 1:


### PR DESCRIPTION
Addresses #15 

This just adds a note to the setup in the readme. To actually run a check of the CUDA environment loaded is more difficult -- the only place it needs to be checked actually is in the `hera-sim-vis.py` script, which is not in this repo.