### PR TITLE
Updated run_sky_model.py to account for hpc-config yaml and prioritize it.

### DIFF
--- a/core/run_sky_model.py
+++ b/core/run_sky_model.py
@@ -35,9 +35,18 @@ def run_make_sky_model(
         ),
     )
 
-    if "time" not in [x[0] for x in slurm_override]:
-        slurm_override = slurm_override + (("time", "0-00:15:00"),)
+    # if "time" not in [x[0] for x in slurm_override]:
+    #     slurm_override = slurm_override + (("time", "0-00:15:00"),)
 
+    # Precedence for sbatch walltime:
+    # 1) CLI : slurm-override 
+    # 2) Default : hpc-sonfig/*.yaml
+    # 3) Fallback : run_sky_model.py 
+    have_cli_time = any(k == "time" for k, _ in slurm_override)
+    yaml_time = ( utils.HPC_CONFIG.get("slurm", {}).get("sky-model", {}).get("time") or utils.HPC_CONFIG.get("slurm", {}).get("cpu", {}).get("time") )
+    if not have_cli_time and not yaml_time:
+        slurm_override = slurm_override + (("time", "0-00:15:00"),)
+    
     # Make the SBATCH script minus hera-sim-vis.py command
     program = _get_sbatch_program(gpu=False, slurm_override=slurm_override)
 

--- a/hpc-configs/NRAO_H6C.yaml
+++ b/hpc-configs/NRAO_H6C.yaml
@@ -1,0 +1,29 @@
+# Template for HPC config for run_sim.py
+# None-number values should be quoted 
+
+paths:
+  beams: "/lustre/aoc/projects/hera/rchandra/H6C_Validation_Stats/hera-beams/beams"
+conda:
+  # Path will be resolved
+  conda_path: "/home/rasch/anaconda3"
+  environment_name: "myenv_validation_1"
+
+module:
+  # List environment modules to load
+  - "mpi"
+
+slurm:
+  # SLURM SBATCH options, listed as --flag: value
+  # Flags not shown here should work
+  # There is no GPU on NRAO!
+  cpu:
+    partition: "batch"  # Name of partition
+    nodes: 1  # Number of nodes
+    mem: "240GB"  # Memory with unit
+    ntasks: 16  # Number of tasks
+    time: "0-04:00:00"  # slurm-aware time string format
+
+  # sky-model:
+  #   time: "0-04:00:00"
+
+    


### PR DESCRIPTION
    # if "time" not in [x[0] for x in slurm_override]:
    #     slurm_override = slurm_override + (("time", "0-00:15:00"),)

Vs

    # Precedence for sbatch walltime:
    # 1) CLI : slurm-override
    # 2) Default : hpc-sonfig/*.yaml
    # 3) Fallback : run_sky_model.py
    have_cli_time = any(k == "time" for k, _ in slurm_override)
    yaml_time = ( utils.HPC_CONFIG.get("slurm", {}).get("sky-model", {}).get("time") or utils.HPC_CONFIG.get("slurm", {}).get("cpu", {}).get("time") )
    if not have_cli_time and not yaml_time:
        slurm_override = slurm_override + (("time", "0-00:15:00"),)